### PR TITLE
Add blastAMR to the index

### DIFF
--- a/pkg/blastamr/blastamr.json
+++ b/pkg/blastamr/blastamr.json
@@ -1,0 +1,9 @@
+{
+    "name": "blastAMR",
+    "repo": "github.com/STFS-TUDa/blastAMR",
+    "description": "A Load-balanced adaptive mesh refinement library for OpenFOAM",
+    "type": "lib",
+    "build": ["wmake src/errorEstimators", "wmake src/dynamicMesh", "wmake src/dynamicFvMesh", "wmake applications/utilities/updateMesh"],
+    "version": ">=2212",
+    "keywords": ["AMR", "load-balancing", "adaptive mesh refinement"]
+}

--- a/pkg/blastamr/blastamr.json
+++ b/pkg/blastamr/blastamr.json
@@ -4,6 +4,6 @@
     "description": "A Load-balanced adaptive mesh refinement library for OpenFOAM",
     "type": "lib",
     "build": ["wmake src/errorEstimators", "wmake src/dynamicMesh", "wmake src/dynamicFvMesh", "wmake applications/utilities/updateMesh"],
-    "version": ">=2212",
+    "version": [">=2212"],
     "keywords": ["AMR", "load-balancing", "adaptive mesh refinement"]
 }


### PR DESCRIPTION
I have set the `type` to `lib` for now, which is what most of the repo is about.
But the repo is technically not functional if users don't compile/use a utility I call `updateMesh`.

I suggest the following expansion on the `type` keyword:
- `type` can support any, or a combination of `lib`, `utility`, `solver`, `adapter`
- combinations can be expressed as `lib+solver` for example.
- `build` then can be expanded to host commands for each "type", so we would have `build.lib`, `build.solver` as a list.

It's also important to honor environment vars, or to source an `etc/bashrc` if provided, so this also needs to be added to the `build` "standard".

See #2 for control over the index standard.
On request at STFS-TUDa/blastAMR#15