### PR TITLE
Add porousMicroTransport package

### DIFF
--- a/pkg/porousmicrotransport/porousmicrotransport.json
+++ b/pkg/porousmicrotransport/porousmicrotransport.json
@@ -1,0 +1,9 @@
+{
+    "name": "porousMicroTransport",
+    "repo": "github.com/gerlero/porousMicroTransport",
+    "description": "OpenFOAM solvers for flow and transport in porous media in paper-based microfluidics",
+    "type": "app",
+    "build": ["Allwmake"],
+    "version": [">=2112"],
+    "keywords": ["microfluidics", "porous media", "lab-on-a-chip", "paper-based"]
+}


### PR DESCRIPTION
Closes https://github.com/gerlero/porousMicroTransport/issues/165.

I've listed it as an `app` since it the package is meant to be used through its third-party solvers, even though it includes its own libs. 

For now, it doesn't have any requirements other than OpenFOAM >= v2112; although in the future I might want to add https://github.com/gerlero/reagency as a (non-required) dependency. I know you're working on adding dependency support though.