### PR TITLE
Fix 'porousmicrotransport' repo URL

### DIFF
--- a/pkg/porousmicrotransport/metadata.json
+++ b/pkg/porousmicrotransport/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "porousMicroTransport",
-    "repo": "github.com/gerlero/porousMicroTransport",
+    "repo": "https://github.com/gerlero/porousMicroTransport",
     "description": "OpenFOAM solvers for flow and transport in porous media in paper-based microfluidics",
     "type": "app",
     "version": [">=2112"],


### PR DESCRIPTION
@greole Either this 'fix', or the `https://` part could be made optional. I'd prefer the `https://` to be there, but it's your call.