### PR TITLE
Remove version specifier of city4cfd

### DIFF
--- a/pkg/city4cfd/metadata.json
+++ b/pkg/city4cfd/metadata.json
@@ -4,6 +4,5 @@
     "description": "Reconstruction of 3D city geometries for urban CFD simulations",
     "type": "app",
     "build": [],
-    "version": ["*"],
     "keywords": ["geometry reconstruction", "preprocessing"]
 }


### PR DESCRIPTION
Remove the non-standard `"*"` version specifier, as the package manager won't understand it. Skipping a version field altogether will accomplish what is probably desired here.