### PR TITLE
Allow specifying dependencies

### DIFF
--- a/.github/index-schema.json
+++ b/.github/index-schema.json
@@ -65,6 +65,12 @@
         ]
       }
     },
+    "requires": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "keywords": {
       "type": "array",
       "items": {

--- a/pkg/porousmicrotransport/metadata.json
+++ b/pkg/porousmicrotransport/metadata.json
@@ -4,6 +4,6 @@
     "description": "OpenFOAM solvers for flow and transport in porous media in paper-based microfluidics",
     "type": "app",
     "version": [">=2112"],
-    "requires": ["reagency"]
+    "requires": ["reagency"],
     "keywords": ["microfluidics", "porous media", "lab-on-a-chip", "paper-based"]
 }

--- a/pkg/porousmicrotransport/metadata.json
+++ b/pkg/porousmicrotransport/metadata.json
@@ -4,5 +4,6 @@
     "description": "OpenFOAM solvers for flow and transport in porous media in paper-based microfluidics",
     "type": "app",
     "version": [">=2112"],
+    "requires": ["reagency"]
     "keywords": ["microfluidics", "porous media", "lab-on-a-chip", "paper-based"]
 }


### PR DESCRIPTION
@greole What do you think of this syntax for specifying dependencies?

We could specify that the package manager has to define an `OPI_DEPENDENCIES` (or similar) environment variable for packages to find their dependencies (i.e. at ```$OPI_DEPENDENCIES/<dependency>```).