### PR TITLE
Add `precice-adapter`

### DIFF
--- a/pkg/precice-adapter/metadata.json
+++ b/pkg/precice-adapter/metadata.json
@@ -3,6 +3,6 @@
     "repo": "https://github.com/precice/openfoam-adapter.git",
     "description": "An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE",
     "type": "lib",
-    "version": [">=2112"],
+    "version": [">=1812"],
     "keywords": ["preCICE", "co-simulation", "multiphysics", "fluid-structure interaction", "conjugate heat transfer"],
 }

--- a/pkg/precice-adapter/metadata.json
+++ b/pkg/precice-adapter/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "OpenFOAM-preCICE adapter",
+    "name": "precice-adapter",
     "repo": "https://github.com/precice/openfoam-adapter.git",
     "description": "An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE",
     "type": "lib",

--- a/pkg/precice-adapter/metadata.json
+++ b/pkg/precice-adapter/metadata.json
@@ -4,5 +4,5 @@
     "description": "An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE",
     "type": "lib",
     "version": [">=1812"],
-    "keywords": ["preCICE", "co-simulation", "multiphysics", "fluid-structure interaction", "conjugate heat transfer"],
+    "keywords": ["preCICE", "co-simulation", "multiphysics", "fluid-structure interaction", "conjugate heat transfer"]
 }

--- a/pkg/precice-adapter/metadata.json
+++ b/pkg/precice-adapter/metadata.json
@@ -1,0 +1,8 @@
+{
+    "name": "OpenFOAM-preCICE adapter",
+    "repo": "https://github.com/precice/openfoam-adapter.git",
+    "description": "An OpenFOAM function object for CHT, FSI, and fluid-fluid coupled simulations using preCICE",
+    "type": "lib",
+    "version": [">=2112"],
+    "keywords": ["preCICE", "co-simulation", "multiphysics", "fluid-structure interaction", "conjugate heat transfer"],
+}


### PR DESCRIPTION
Closes https://github.com/precice/openfoam-adapter/issues/353

Tested with OpenFOAM v2506 (EDIT: and preCICE 3.2.0):

```shell
$ styro install precice-adapter
⏬ Downloading precice-adapter
✅ Package 'precice-adapter' installed successfully.
⚙️ New libraries:
  libpreciceAdapterFunctionObject.so
```

I put in v2112 as a lower bound (there needs to be a bound for styro to detect that it's an ESI-only package), but haven't actually tested with that version. @MakisH is there an official lower bound for the project?

Also, I note that the package install seems to fail silently when preCICE is not available, but that's unrelated to OPI/styro.