### PR TITLE
Add ohc1 repo

### DIFF
--- a/pkg/ohc1/metadata.json
+++ b/pkg/ohc1/metadata.json
@@ -1,0 +1,1 @@
+{"name": "ohc1", "repo": "https://github.com/OpenFOAM-HPC-Challenge/OHC1.git", "description": "Data, scripts and notebooks of the 1st OpenFOAM HPC challenge", "type": "data", "keywords": ["hpc-challenge", "data-set"]}

--- a/pkg/ohc1/metadata.json
+++ b/pkg/ohc1/metadata.json
@@ -1,1 +1,7 @@
-{"name": "ohc1", "repo": "https://github.com/OpenFOAM-HPC-Challenge/OHC1.git", "description": "Data, scripts and notebooks of the 1st OpenFOAM HPC challenge", "type": "data", "keywords": ["hpc-challenge", "data-set"]}
+{
+  "name": "ohc1",
+  "repo": "https://github.com/OpenFOAM-HPC-Challenge/OHC1.git",
+  "description": "Data, scripts and notebooks of the 1st OpenFOAM HPC challenge",
+  "type": "data",
+  "keywords": ["hpc-challenge", "data-set"]
+}


### PR DESCRIPTION
This PR adds the data repository of the 1st OpenFOAM HPC challenge. See https://github.com/OpenFOAM-HPC-Challenge/OHC1